### PR TITLE
feat(home): make announcement text look better in light mode

### DIFF
--- a/components/announcement/Hero.vue
+++ b/components/announcement/Hero.vue
@@ -14,8 +14,8 @@ const hasActiveAnnouncement = activeAnnouncements.length > 0;
 </script>
 
 <template>
-    <div class="absolute top-1/4 motion-safe:md:animate-[scalein_1s_ease-in-out_forwards] break-all font-semibold">
-        <ContentRenderer v-if="hasActiveAnnouncement" :value="activeAnnouncements[0]" class="bg-gradient-to-r from-italygreen via-white to-italyred text-transparent bg-clip-text" />
+    <div class="absolute top-1/4 motion-safe:md:animate-[scalein_1s_ease-in-out_forwards] break-all font-semibold drop-shadow-md">
+        <ContentRenderer v-if="hasActiveAnnouncement" :value="activeAnnouncements[0]" class="bg-gradient-to-r from-italygreen dark:via-white via-neutral-300 to-italyred dark:to-italyred text-transparent bg-clip-text" />
     </div>
     <EasterEggConfetti v-if="hasActiveAnnouncement" />
 </template>


### PR DESCRIPTION
Before:
![image](https://github.com/Tougrel/Pestoverse/assets/137009494/136b4e42-305b-4d43-a43a-8d54f1b3cfd4)
After:
![image](https://github.com/Tougrel/Pestoverse/assets/137009494/1bb5478f-9aca-48d9-b184-9e697eec3411)

For some bizarre reason when I added a variable `via` colour, the `to` colour completely disappeared, so had to define separately for dark and light mode 🤷🏻 

https://feat-announcement-message.pestoverse-ikanexus.pages.dev/