### PR TITLE
Sort Suggestions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+NUXT_NEXTAUTH_SECRET="changeme"
+NUXT_NEXTAUTH_URL="http://localhost:3000"
+NUXT_DISCORD_ID="changeme"
+NUXT_DISCORD_SECRET="changeme"

--- a/server/api/submissions/names.get.ts
+++ b/server/api/submissions/names.get.ts
@@ -18,7 +18,8 @@ export default defineEventHandler(async (event) => {
                 .map((submission) => submission.submission?.toLowerCase())
                 .filter((item, index, arr) => {
                     return arr.indexOf(item) === index;
-                });
+                })
+                .sort();
         },
         15 * 60, // 15 minutes
     );


### PR DESCRIPTION
Suggestions have a very weird order currently - adding .sort() on the end to make sure we stay alphabetical
![image](https://github.com/Tougrel/Pestoverse/assets/137009494/5be71350-b540-4f95-878b-9741dc49be1f)
->
![image](https://github.com/Tougrel/Pestoverse/assets/137009494/f924fa00-318e-42f3-84de-4aff05690cd2)


added an example .env file as well